### PR TITLE
Update apollo-client to 3

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -13,3 +13,4 @@ generates:
       withHooks: true
       withHOC: false
       withComponent: false
+      reactApolloVersion: 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,24 +58,49 @@
         "cross-fetch": "3.0.5"
       }
     },
-    "@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+    "@apollo/client": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.1.1.tgz",
+      "integrity": "sha512-c5DxrU81p0B5BsyBXm+5uPJqLCX2epnBsd87PXfRwzDLbp/NiqnWp6a6c5vT5EV2LwJuCq1movmKthoy0gFb0w==",
       "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.5.2",
+        "@wry/equality": "^0.2.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.11.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.12.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^1.2.0",
         "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "@wry/context": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
+          "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@wry/equality": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
+          "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "optimism": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
+          "integrity": "sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==",
+          "requires": {
+            "@wry/context": "^0.5.2"
+          }
+        }
       }
     },
     "@ardatan/aggregate-error": {
@@ -2374,23 +2399,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
-      "requires": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -2563,110 +2571,6 @@
             "remove-trailing-separator": "^1.0.1"
           }
         }
-      }
-    },
-    "apollo-boost": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.9.tgz",
-      "integrity": "sha512-05y5BKcDaa8w47f8d81UVwKqrAjn8uKLv6QM9fNdldoNzQ+rnOHgFlnrySUZRz9QIT3vPftQkEz2UEASp1Mi5g==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-cache-inmemory": "^1.6.6",
-        "apollo-client": "^2.6.10",
-        "apollo-link": "^1.0.6",
-        "apollo-link-error": "^1.0.3",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "apollo-link-error": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
-      "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
       }
     },
     "aproba": {
@@ -5243,6 +5147,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hsl-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
@@ -6982,14 +6894,6 @@
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
-      "requires": {
-        "@wry/context": "^0.4.0"
       }
     },
     "os-browserify": {
@@ -9966,15 +9870,6 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,20 +10,19 @@
     "codegen": "gql-gen"
   },
   "dependencies": {
-    "@apollo/react-hooks": "^3.1.5",
+    "@apollo/client": "^3.1.1",
+    "@graphql-codegen/cli": "^1.17.0",
+    "@graphql-codegen/introspection": "^1.17.0",
+    "@graphql-codegen/typescript": "^1.17.0",
+    "@graphql-codegen/typescript-operations": "^1.17.0",
+    "@graphql-codegen/typescript-react-apollo": "^1.17.0",
     "@types/react": "^16.9.43",
-    "apollo-boost": "^0.4.9",
     "graphql": "^15.2.0",
     "hasura-cli": "^1.3.0",
     "minireset.css": "0.0.6",
     "next": "^9.5.1",
     "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "@graphql-codegen/cli": "^1.17.0",
-    "@graphql-codegen/introspection": "^1.17.0",
-    "@graphql-codegen/typescript": "^1.17.0",
-    "@graphql-codegen/typescript-operations": "^1.17.0",
-    "@graphql-codegen/typescript-react-apollo": "^1.17.0"
+    "react-dom": "16.13.1"
   },
   "devDependencies": {
     "typescript": "^3.9.6"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,10 +2,12 @@ import "minireset.css";
 import "../variables.css";
 import "../base.css";
 
-import { ApolloClient } from "apollo-client";
-import { InMemoryCache } from "apollo-cache-inmemory";
-import { HttpLink } from "apollo-link-http";
-import { ApolloProvider } from "@apollo/react-hooks";
+import {
+  ApolloClient,
+  ApolloProvider,
+  InMemoryCache,
+  HttpLink,
+} from "@apollo/client";
 
 const createApolloClient = () => {
   return new ApolloClient({
@@ -24,4 +26,4 @@ export default function MyApp({ Component, pageProps }) {
       <Component {...pageProps} />
     </ApolloProvider>
   );
-};
+}


### PR DESCRIPTION
appolo-clientを3に更新した。 close #45 

* いろんなパッケージから色々引っ張ってきていたが、`@apollo/client`から取得する形になった。
* codegenのオプションにapolloのバージョンを指定するオプションがあったので指定した。
    * 以前は`@apollio/react-hooks`から`useQuery`をimportしていたが、`@apollo/client`からexportされたものを使う形に変更されている。
